### PR TITLE
Support for singel select lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The task needs special configuration in `exportimportconfig.py` (see sample in
 * `ADD_COMMENT_TO_OLD_ISSUE`: if `True`, add comment to source JIRA issue that it was exported to new issue in target JIRA with issue link
 * `CUSTOM_FIELD`: a single custom field that you can set to a default value for all issues (set to `None` if not needed)
 * `CUSTOM_FIELD_MAP`: map source JIRA fields to target JIRA fields. This can also be used for system fields that are not mapped out of the box, such as 'environment'
+* `CUSTOM_FIELD_MAP_MAPPED`: mapped values of customfields for select lists. With these maps single select lists can be exported and imported, values will be mappes similarly to other mapped values. 
 
 Note that epics and sub-tasks should be excluded from the source JIRA query as
 they are automatically imported via the parent task. The recommended

--- a/exportimportconfig-sample.py
+++ b/exportimportconfig-sample.py
@@ -118,3 +118,11 @@ CUSTOM_FIELD_MAP = {
         'customfield_10402': 'customfield_11312', # Expected Behavior
 }
 
+# Dict of tuples where tuple is ( fieldname, dict of valuemappings)
+# Works for fields that have {'value': x } structure, like single select lists
+CUSTOM_FIELD_MAP_MAPPED = {
+    'customfield_11486': ('customfield_10108', {
+        'Sourcevalue': 'Destinationvalue'
+    })
+}
+

--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -182,14 +182,24 @@ def _get_dest_issue_fields(fields, conf):
                             '%(fieldname)s_MAP and DEFAULT_%(fieldname)s is not set' %
                             {'value': value, 'fieldname': fieldname.upper()})
             result[fieldname] = {'name': mapped_value}
+    # Single field
     if conf.CUSTOM_FIELD:
         result[conf.CUSTOM_FIELD[0]] = conf.CUSTOM_FIELD[1]
+    # Map of simple text/number fields
     if conf.CUSTOM_FIELD_MAP:
         for sourcename in conf.CUSTOM_FIELD_MAP.keys():
             targetname = conf.CUSTOM_FIELD_MAP[sourcename]
             value = getattr(fields, sourcename, None)
             if value:
                 result[targetname] = value
+    # Map of tuples with mapped values on both sides (select lists. No multiselect)
+    if conf.CUSTOM_FIELD_MAP_MAPPED:
+        for sourcename in conf.CUSTOM_FIELD_MAP_MAPPED.keys():
+            targetname = conf.CUSTOM_FIELD_MAP_MAPPED[sourcename][0]
+            sourcevalue = getattr(getattr(fields, sourcename, None),'value',None)
+            value = conf.CUSTOM_FIELD_MAP_MAPPED[sourcename][1].get(sourcevalue,None)
+            if value:
+                result[targetname] = {'value': value }                
     return result
 
 


### PR DESCRIPTION
Add new config option for mapping custom single value fields, like single selects (that have {'value':x} structure.